### PR TITLE
[nightshift] lint-fix: resolve 3 E501 line-length violations

### DIFF
--- a/bot/commands/login.py
+++ b/bot/commands/login.py
@@ -43,7 +43,8 @@ class LoginCommands(app_commands.Group):
             if not start.get("success") or not start.get("qr_png"):
                 await interaction.followup.send(
                     _truncate_discord_message(
-                        f"❌ Failed to start QR login: {_short_error(str(start.get('error', 'Unknown error')))}"
+                        f"❌ Failed to start QR login: "
+                        f"{_short_error(str(start.get('error', 'Unknown error')))}"
                     ),
                     ephemeral=True,
                 )
@@ -144,7 +145,10 @@ class LoginCommands(app_commands.Group):
             file = discord.File(io.BytesIO(p.read_bytes()), filename=p.name or "xianyu_state.json")
 
             await interaction.followup.send(
-                f"✅ Exported login state to `{out_path}` (cookies: {cookie_count}). Attached file:",
+                (
+                    f"✅ Exported login state to `{out_path}` "
+                    f"(cookies: {cookie_count}). Attached file:"
+                ),
                 file=file,
                 ephemeral=True,
             )

--- a/core/scanner.py
+++ b/core/scanner.py
@@ -352,7 +352,8 @@ class GoofishClient:
                 await page.add_init_script(
                     """
                     Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
-                    Object.defineProperty(navigator, 'languages', { get: () => ['zh-CN', 'zh', 'en'] });
+                    Object.defineProperty(navigator, 'languages',
+                        { get: () => ['zh-CN', 'zh', 'en'] });
                     Object.defineProperty(navigator, 'plugins', { get: () => [1,2,3,4,5] });
                     window.navigator.chrome = { runtime: {} };
                     """


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** lint-fix
**Category:** pr
**Changes:** Fixed 3 E501 (line too long) violations detected by ruff in `bot/commands/login.py` and `core/scanner.py`. All lines now comply with the 100-char limit defined in `pyproject.toml`.

**Files modified:**
- `bot/commands/login.py` — Split 2 long f-string lines
- `core/scanner.py` — Split 1 long JS init script line

After: `ruff check .` → All checks passed!

Merge if useful, close if not.